### PR TITLE
refine prompting for ollama models

### DIFF
--- a/R/chores.R
+++ b/R/chores.R
@@ -41,9 +41,9 @@
 #'
 "chores"
 
-chores_eval <- function(solver_chat, name = task_name(solver_chat)) {
+chores_eval <- function(solver_chat, name = task_name(solver_chat), ...) {
   tsk <- chores_task()
-  tsk$eval(solver_chat = solver_chat)
+  tsk$eval(solver_chat = solver_chat, ...)
   saveRDS(
     tsk,
     file = paste0("data-raw/chores/tasks/", name, ".rds")

--- a/R/scorer.R
+++ b/R/scorer.R
@@ -26,11 +26,15 @@
 chores_scorer <- function(
   samples,
   ...,
-  scorer_chat = ellmer::chat_anthropic(model = "claude-sonnet-4-20250514")
+  scorer_chat = ellmer::chat_anthropic(model = "claude-sonnet-4-20250514"),
+  remove_xml_tags = FALSE
 ) {
   # first, filter out all `result`s that aren't valid R code;
   # those will receive a score of 0
   result <- samples$result
+  if (isTRUE(remove_xml_tags)) {
+    result <- purrr::map_chr(result, remove_xml_tags)
+  }
   result_is_valid_r_code <- purrr::map_lgl(result, is_valid_r_code)
   result_indices_to_grade <- which(result_is_valid_r_code)
 
@@ -138,4 +142,8 @@ is_valid_r_code <- function(x) {
     },
     error = function(e) FALSE
   )
+}
+
+remove_xml_tags <- function(x) {
+  gsub("<[^>]*>[^<]*</[^>]*>", "", x)
 }

--- a/R/scorer.R
+++ b/R/scorer.R
@@ -82,7 +82,11 @@ chores_scorer <- function(
   # tidy up + calculate numeric scores
   res <- dplyr::mutate(res, across(everything(), ~ dplyr::na_if(., "NA")))
 
-  res$duration <- unname(unlist(samples$solver_metadata))
+  res$duration <- purrr::map_dbl(
+    samples$solver_metadata,
+    purrr::pluck,
+    "duration"
+  )
   res$duration_penalty <- purrr::map_dbl(res$duration - 2, max, 0)
   res <- dplyr::rowwise(res)
   res <- dplyr::mutate(

--- a/R/solver.R
+++ b/R/solver.R
@@ -20,7 +20,13 @@
 #' @seealso [chores_dataset] for the dataset this solver processes, and
 #'  [chores_task()] to combine this solver with the chores dataset and scorer.
 #' @export
-chores_solver <- function(inputs, ..., solver_chat, disable_thinking = FALSE) {
+chores_solver <- function(
+  inputs,
+  ...,
+  solver_chat,
+  disable_thinking = FALSE,
+  push_system_prompt = FALSE
+) {
   check_inherits(solver_chat, "Chat")
 
   ch <- solver_chat$clone()
@@ -44,6 +50,12 @@ chores_solver <- function(inputs, ..., solver_chat, disable_thinking = FALSE) {
       input <- paste0(c(input, disable_thinking_keyword(ch)), collapse = "\n\n")
     }
     ch_i <- ch$clone()
+    # Optionally inline the contents of the system prompt into the user turn,
+    # as recommended by some ollama models (#2)
+    if (isTRUE(push_system_prompt)) {
+      input <- paste0(c(ch_i$get_system_prompt(), input), collapse = "\n\n")
+      ch_i$set_system_prompt(NULL)
+    }
     time_start <- proc.time()
     ch_i$chat(input, echo = FALSE)
     time_end <- proc.time()

--- a/R/solver.R
+++ b/R/solver.R
@@ -41,7 +41,7 @@ chores_solver <- function(inputs, ..., solver_chat, disable_thinking = FALSE) {
     input <- inputs[i]
     # Allow turning off <think></think> for ollama models (#2)
     if (isTRUE(disable_thinking)) {
-      paste0(c(input, disable_thinking_keyword(ch)), collapse = "\n\n")
+      input <- paste0(c(input, disable_thinking_keyword(ch)), collapse = "\n\n")
     }
     ch_i <- ch$clone()
     time_start <- proc.time()


### PR DESCRIPTION
In https://github.com/simonpcouch/choreseval/commit/5f537142a6a19e14665673f2c1220e1e426eb9d1, both gemma3:12b and mistral-small3.2 got zeroes because of 1) <think> tags resulting in unparsable R code, 2) thinking resulting in many more tokens being streamed than is necessary, and 3) much better instruction following when the prompt is all contained in the user prompt than in the system prompt.

I'd like to see if addressing those issues would make it possible for some local models to do well as chore helpers:

* [x] add option to remove `<think>` (or other XML) tags from responses
* [x] some models have a `/no_think` sort of keyword. It seems it often means the XML tags are still included, but nothing is included inside of them. We could maintain a dictionary of model x keyword pairs to disable thinking by automatically inlining the keyword into the prompt.
* [x] add an option to push the system prompt into prefixing the user prompt. It might end up that we just do so `if (is_ollama())` .

All of these would also have to happen in chores/streamy itself if it does work here.